### PR TITLE
Enable aux_alias test case

### DIFF
--- a/docs/testcase_failure_analysis.md
+++ b/docs/testcase_failure_analysis.md
@@ -1,8 +1,8 @@
 # Test failure analysis document
 
 This file contains list of failures and skips identified when testing the release on tgt_tfa_fvp target with TF-RMM and TF-A.<br />
-TF-RMM Hash: 362d35e56b893bfdae70dae0bed29f724e71d2f7 <br />
-TF-A Hash: e372c291532ef1c0644edbd9c1a1d6b2f167402c <br />
+TF-RMM Hash: f16509d96ba87bd4ec99c745c6fd1a99d9b15407 <br />
+TF-A Hash: 9244331f354af870a2f38775aaaddb47bbec7b39<br />
 The reason for each failing/skipping test is listed here in this file.<br />
 
 ## List of skipped tests
@@ -18,4 +18,4 @@ Arm CCA RMM ACS is distributed under BSD-3-Clause License.
 
 --------------
 
-*Copyright (c) 2023-2024, Arm Limited or its affliates. All rights reserved.*
+*Copyright (c) 2023-2025, Arm Limited or its affliates. All rights reserved.*

--- a/test/command/cmd_rec_create/rmi_rec_create_data.h
+++ b/test/command/cmd_rec_create/rmi_rec_create_data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -181,11 +181,11 @@ static struct stimulus test_data[] = {
     .label = AUX_UNALIGNED,
     .status = RMI_ERROR_INPUT,
     .index = 0},
-//    {.msg = "aux_alias",
-//    .abi = RMI_REC_CREATE,
-//    .label = AUX_ALIASED,
-//    .status = RMI_ERROR_INPUT,
-//    .index = 0},
+    {.msg = "aux_alias",
+    .abi = RMI_REC_CREATE,
+    .label = AUX_ALIASED,
+    .status = RMI_ERROR_INPUT,
+    .index = 0},
     {.msg = "aux_state",
     .abi = RMI_REC_CREATE,
     .label = AUX_UNDELEGATED,


### PR DESCRIPTION
- the bug causing assertion in TF-RMM has been fixed : https://review.trustedfirmware.org/c/TF-RMM/tf-rmm/+/33981