### PR TITLE
fix : Fix build issue when CC is taken from PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 #-------------------------------------------------------------------------------
 
-project(rmm-acs LANGUAGES C ASM)
+project(rmm-acs LANGUAGES)
 
 ### Tool dependency check - start ###
 

--- a/tools/lib/xlat_tables_v2/CMakeLists.txt
+++ b/tools/lib/xlat_tables_v2/CMakeLists.txt
@@ -1,10 +1,11 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 #-------------------------------------------------------------------------------
 
+project(xlat-lib LANGUAGES C ASM)
 
 file(GLOB XLAT_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.S"


### PR DESCRIPTION
- CMake project() function configures the compilers automatically when passed with languages and takes system C compiler as custom toolchain is initailized later. This causes issues when build flag is passed with compiler name directly and cmake is expected to take it from PATH environment variable.
