### PR TITLE
Add option to override UART base address

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,11 @@ if(NOT DEFINED RMM_SPEC_VER)
     set(RMM_SPEC_VER "ALL")
 endif()
 
+#Check if UART_NS_OVERRIDE is set, if set add the definition.
+if(DEFINED UART_NS_OVERRIDE)
+    add_definitions(-DUART_NS_OVERRIDE=${UART_NS_OVERRIDE})
+endif()
+
 #Check if RMM_SPEC_VER is set correctly and add definitions accordingly
 CheckSpecVersionAndAddDefinitions(${RMM_SPEC_VER})
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ make
 - -RMM_ACS_TARGET_QCBOR=<path_for_pre_fetched_cbor_folder> this is option used where no network  connectivity is possible during the build.
 - -DSECURE_TEST_ENABLE=<value_to_enable_secure_test> Enable secure test macro definition and it will run secure test in regression. Valid value is 1. By default this macro will not define and secure test will not run in regression.
 - -DRMM_SPEC_VER=<value_to_select_specification_version> Select the Specification version to test against. Current supported values are RMM_V_1_0, RMM_V_1_1 and ALL. If this flag is not set during compilation, ALL is selected by default.
+- -DUART_NS_OVERRIDE=<value_of_uart_base_address> To override the default NS UART base address defined in the plat/targets/*
 
 *To compile tests for tgt_tfa_fvp platform*:<br />
 ```

--- a/plat/targets/tgt_tfa_fvp/inc/pal_config_def.h
+++ b/plat/targets/tgt_tfa_fvp/inc/pal_config_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -45,7 +45,11 @@
  */
 
 /* Non-secure UART - PL011_UART2_BASE */
+#ifdef UART_NS_OVERRIDE
+#define PLATFORM_NS_UART_BASE    UART_NS_OVERRIDE
+#else
 #define PLATFORM_NS_UART_BASE    0x1c0b0000
+#endif
 #define PLATFORM_NS_UART_SIZE    0x10000
 
 /* Non-volatile memory range assigned */


### PR DESCRIPTION
- This change adds a option to override the default UART base address defined in the plat/target/ config files. For example for target tgt_tfa_fvp the default uart base address is of UART2, if this needs to be overriden the new build flag can be used.