### PR TITLE
Disabling FEAT_LPA2 test cases

### DIFF
--- a/test/memory_management/mm_rtt_level_start/mm_rtt_level_start_host.c
+++ b/test/memory_management/mm_rtt_level_start/mm_rtt_level_start_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023,2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -25,7 +25,7 @@ static uint32_t create_realm(val_host_realm_ts *realm)
     }
 
     ipa_width = VAL_EXTRACT_BITS(realm->s2sz, 0, 7);
-    for (i = 0; i < 23; i++)
+    for (i = 0; i < sizeof(rtt_sl_start) / sizeof(rtt_sl_start[0]); i++)
     {
         if (ipa_width != rtt_sl_start[i][0])
             continue;
@@ -107,11 +107,14 @@ void mm_rtt_level_start_host(void)
     val_host_realm_ts realm;
     uint64_t ret;
     uint64_t s2sz_supp = 0, i;
-    uint8_t arr[5][4] = {{32, 32, 2, 4},
+    uint8_t arr[][4] = {{32, 32, 2, 4},
                          {36, 34, 2, 16},
                          {40, 40, 1, 2},
                          {42, 42, 1, 8},
-                         {52, 52, 0, 16} };
+#ifdef ENABLE_LPA2 /* Needs LPA2 support in XLAT to enable this */
+                         {52, 52, 0, 16}
+#endif
+                      };
 
     val_memset(&realm, 0, sizeof(realm));
 
@@ -130,7 +133,7 @@ void mm_rtt_level_start_host(void)
 
     LOG(DBG, "\tRMI Features s2sz supp %d %d\n", s2sz_supp, arr[0][0]);
 
-    for (i = 0; i < 5; i++)
+    for (i = 0; i < sizeof(arr)/sizeof(arr[0]); i++)
     {
         if (s2sz_supp < arr[i][0])
             break;

--- a/test/memory_management/mm_rtt_level_start/mm_rtt_level_start_realm.c
+++ b/test/memory_management/mm_rtt_level_start/mm_rtt_level_start_realm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023,2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -24,7 +24,7 @@ void mm_rtt_level_start_realm(void)
     LOG(DBG, "\tIn realm_create_realm REC[0], mpdir=%x\n", val_read_mpidr(), 0);
     ipa_width = val_realm_get_ipa_width();
 
-    for (i = 0; i < 23; i++)
+    for (i = 0; i < sizeof(rtt_sl_start)/sizeof(rtt_sl_start[0]); i++)
     {
         if (ipa_width != rtt_sl_start[i][0])
             continue;

--- a/test/memory_management/mm_rtt_level_start/rtt_level_start.h
+++ b/test/memory_management/mm_rtt_level_start/rtt_level_start.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023,2025, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -8,7 +8,7 @@
 #ifndef _RTT_LEVEL_START_H_
 #define _RTT_LEVEL_START_H_
 
-static uint64_t rtt_sl_start[23][2] = {{32, 0x3ffff000},
+static uint64_t rtt_sl_start[][2] = {{32, 0x3ffff000},
                                       {32, 0x7ffff000},
                                       {32, 0xbffff000},
                                       {32, 0xfffff000},
@@ -24,11 +24,14 @@ static uint64_t rtt_sl_start[23][2] = {{32, 0x3ffff000},
                                       {42, 0xfffffff000},
                                       {42, 0x2fffffff000},
                                       {42, 0x3fffffff000},
+#ifdef ENABLE_LPA2 /* Needs LPA2 support in XLAT to enable this */
                                       {52, 0xffffffffffff},
                                       {52, 0x1ffffffffffff},
                                       {52, 0x8ffffffffffff},
                                       {52, 0x9ffffffffffff},
                                       {52, 0xeffffffffffff},
-                                      {52, 0xfffffffffffff} };
+                                      {52, 0xfffffffffffff}
+#endif
+                                      };
 #endif /* _RTT_LEVEL_START_H_ */
 


### PR DESCRIPTION
- When hardware/RMM suports FEAT_LPA2, ACS runs few test cases where realm is setup with s2sz as 52 and mapping VA/IPA with 52 bits wide. But ACS stage 1 page table library currently does not support LPA2 and the test cases fail. Hence temporarily disbling these test cases till LPA2 support is added.