### PR TITLE
rmm-acs: fix in-tree Coverity defects

### DIFF
--- a/test/attestation_measurement/attestation_rec_exit_irq/attestation_rec_exit_irq_realm.c
+++ b/test/attestation_measurement/attestation_rec_exit_irq/attestation_rec_exit_irq_realm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -22,7 +22,7 @@ void attestation_rec_exit_irq_realm(void)
     val_smc_param_ts args = {0,};
     uint64_t token_size = 0, size, max_size, len;
     __attribute__((aligned (PAGE_SIZE))) uint64_t token[MAX_REALM_CCA_TOKEN_SIZE/8] = {0,};
-    uint64_t *granule = token;
+    uint8_t *granule = (uint8_t *)token;
     uint64_t challenge1[8] = {0xb4ea40d262abaf22,
                              0xe8d966127b6d78e2,
                              0x7ce913f20b954277,
@@ -75,7 +75,8 @@ void attestation_rec_exit_irq_realm(void)
                 granule += PAGE_SIZE;
             }
 
-        } while ((args.x0 == RSI_ERROR_INCOMPLETE) && (granule < token + max_size));
+        } while ((args.x0 == RSI_ERROR_INCOMPLETE) &&
+                 (granule < ((uint8_t *)token + max_size)));
 
         *shared_flag3 = 1;
 

--- a/test/command/cmd_data_create/cmd_data_create_host.c
+++ b/test/command/cmd_data_create/cmd_data_create_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -148,7 +148,7 @@ static uint64_t g_rd_active_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_data_create_unknown/cmd_data_create_unknown_host.c
+++ b/test/command/cmd_data_create_unknown/cmd_data_create_unknown_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -126,7 +126,7 @@ static uint64_t ipa_valid_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_data_destroy/cmd_data_destroy_host.c
+++ b/test/command/cmd_data_destroy/cmd_data_destroy_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -110,7 +110,7 @@ static uint64_t rd_aux_live_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_granule_delegate/cmd_granule_delegate_host.c
+++ b/test/command/cmd_granule_delegate/cmd_granule_delegate_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -57,7 +57,7 @@ static uint64_t g_rd_new_prep_sequence(uint16_t vmid)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_granule_undelegate/cmd_granule_undelegate_host.c
+++ b/test/command/cmd_granule_undelegate/cmd_granule_undelegate_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -60,7 +60,7 @@ static uint64_t g_rd_new_prep_sequence(uint16_t vmid)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_realm_activate/cmd_realm_activate_host.c
+++ b/test/command/cmd_realm_activate/cmd_realm_activate_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -76,7 +76,7 @@ static uint64_t g_rd_null_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_realm_create/cmd_realm_create_host.c
+++ b/test/command/cmd_realm_create/cmd_realm_create_host.c
@@ -356,7 +356,7 @@ static uint64_t params_valid_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_rtt_create/cmd_rtt_create_host.c
+++ b/test/command/cmd_rtt_create/cmd_rtt_create_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -129,7 +129,7 @@ static uint64_t level_no_parent_rtt_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_rtt_destroy/cmd_rtt_destroy_host.c
+++ b/test/command/cmd_rtt_destroy/cmd_rtt_destroy_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -135,6 +135,11 @@ static uint64_t g_rec_ready_prep_sequence(uint64_t vmid)
 
 static uint64_t g_rd_new_prep_sequence(uint16_t vmid)
 {
+    if (vmid >= NUM_REALMS)
+    {
+        LOG(ERROR, "Invalid VMID %u\n", vmid);
+        return VAL_TEST_PREP_SEQ_FAILED;
+    }
     val_memset(&realm[vmid], 0, sizeof(realm[vmid]));
 
     realm[vmid].s2sz = 40;

--- a/test/command/cmd_rtt_init_ripas/cmd_rtt_init_ripas_host.c
+++ b/test/command/cmd_rtt_init_ripas/cmd_rtt_init_ripas_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -140,7 +140,7 @@ static uint64_t g_rd_null_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_rtt_map_unprotected/cmd_rtt_map_unprotected_host.c
+++ b/test/command/cmd_rtt_map_unprotected/cmd_rtt_map_unprotected_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -153,7 +153,7 @@ static uint64_t desc_addr_in_lpa2_range_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rec_count = 1;

--- a/test/command/cmd_rtt_read_entry/cmd_rtt_read_entry_host.c
+++ b/test/command/cmd_rtt_read_entry/cmd_rtt_read_entry_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -106,10 +106,11 @@ static uint64_t level_invalid_oob_prep_sequence(void)
 
 static uint64_t g_rec_ready_prep_sequence(uint64_t rd)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     val_host_rec_params_ts rec_params;
 
     realm.rd = rd;
+    realm.rec_count = 1;
     rec_params.pc = 0;
     rec_params.flags = RMI_RUNNABLE;
 

--- a/test/command/cmd_rtt_unmap_unprotected/cmd_rtt_unmap_unprotected_host.c
+++ b/test/command/cmd_rtt_unmap_unprotected/cmd_rtt_unmap_unprotected_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -75,6 +75,11 @@ static uint64_t g_rec_ready_prep_sequence(uint64_t vmid)
 
 static uint64_t g_rd_new_prep_sequence(uint16_t vmid)
 {
+    if (vmid >= NUM_REALMS)
+    {
+        LOG(ERROR, "Invalid VMID %u\n", vmid);
+        return VAL_TEST_PREP_SEQ_FAILED;
+    }
     val_memset(&realm[vmid], 0, sizeof(realm[vmid]));
 
     realm[vmid].s2sz = 40;

--- a/test/command/common/command_common_host.c
+++ b/test/command/common/command_common_host.c
@@ -195,6 +195,8 @@ uint32_t val_host_rec_create_common(val_host_realm_ts *realm, val_host_rec_param
 
     }
 
+    val_memset(&rec_create_flags, 0x0, sizeof(rec_create_flags));
+
     /* Allocate memory for rec_params */
     rec_params = val_host_mem_alloc(PAGE_SIZE, PAGE_SIZE);
     if (rec_params == NULL)

--- a/test/exception/common/exception_common_host.c
+++ b/test/exception/common/exception_common_host.c
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -19,8 +19,8 @@ void exception_copy_exit_to_entry(val_host_rec_enter_ts *rec_enter,
                                            val_host_rec_exit_ts *rec_exit)
 {
     rec_enter->gicv3_hcr = rec_exit->gicv3_hcr;
-    val_memcpy(rec_enter->gprs, rec_exit->gprs, VAL_REC_HVC_NUM_GPRS);
-    val_memcpy(rec_enter->gicv3_lrs, rec_exit->gicv3_lrs, VAL_REC_GIC_NUM_LRS);
+    val_memcpy(rec_enter->gprs, rec_exit->gprs, sizeof(rec_enter->gprs));
+    val_memcpy(rec_enter->gicv3_lrs, rec_exit->gicv3_lrs, sizeof(rec_enter->gicv3_lrs));
 }
 
 uint64_t exception_validate_rec_exit_ripas(exception_rec_exit_ts rec_exit_exception)

--- a/test/exception/common/exception_common_realm.h
+++ b/test/exception/common/exception_common_realm.h
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -16,7 +16,7 @@
 
 #define EXCEPTION_TEST_MAX_GPRS 31
 #define EXCEPTION_TEST_HOSTCALL_GPRS_CHECK_COUNT 7
-#define EXCEPTION_TEST_PSCI_GPRS_CHECK_COUNT 7
+#define EXCEPTION_TEST_PSCI_GPRS_COMPARE_START 7
 
 #define MPIDR_AFFLVL_MASK    ULL(0xff)
 #define MPIDR_AFF3_SHIFT    U(32)

--- a/test/exception/exception_rec_exit_irq/exception_rec_exit_irq_host.c
+++ b/test/exception/exception_rec_exit_irq/exception_rec_exit_irq_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -21,7 +21,7 @@ static int wd_irq_handler(void)
 
 void exception_rec_exit_irq_host(void)
 {
-    val_host_realm_ts realm;
+    val_host_realm_ts realm = {0};
     uint64_t ret;
     val_host_rec_exit_ts *rec_exit = NULL;
     val_host_rec_enter_ts *rec_enter = NULL;

--- a/test/exception/exception_rec_exit_psci/exception_rec_exit_psci_host.c
+++ b/test/exception/exception_rec_exit_psci/exception_rec_exit_psci_host.c
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -51,9 +51,11 @@ void exception_rec_exit_psci_host(void)
     }
     else
     {
-        /* corrupting the gpr value*/
-        rec_enter->gprs[5] = 0;
         exception_copy_exit_to_entry(rec_enter, rec_exit);
+
+        /* corrupting the gpr value*/
+        rec_enter->gprs[19] = 0xABCD;
+
         LOG(TEST, "Rec Exit is dueto  psci, ret=%x\n", ret);
         /* if gprs[1] holds the mpidr value then need to send the psci complete message*/
         if (

--- a/test/exception/exception_rec_exit_psci/exception_rec_exit_psci_realm.c
+++ b/test/exception/exception_rec_exit_psci/exception_rec_exit_psci_realm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -7,97 +7,95 @@
 #include "exception_common_realm.h"
 
 #define CONTEXT_ID 0x5555
+#define EXCEPTION_STORE_ALL_GPRS(base_reg)                                    \
+    "str x0,  [" base_reg ", #0]\n\t"                                         \
+    "str x1,  [" base_reg ", #8]\n\t"                                         \
+    "str x2,  [" base_reg ", #16]\n\t"                                        \
+    "str x3,  [" base_reg ", #24]\n\t"                                        \
+    "str x4,  [" base_reg ", #32]\n\t"                                        \
+    "str x5,  [" base_reg ", #40]\n\t"                                        \
+    "str x6,  [" base_reg ", #48]\n\t"                                        \
+    "str x7,  [" base_reg ", #56]\n\t"                                        \
+    "str x8,  [" base_reg ", #64]\n\t"                                        \
+    "str x9,  [" base_reg ", #72]\n\t"                                        \
+    "str x10, [" base_reg ", #80]\n\t"                                        \
+    "str x11, [" base_reg ", #88]\n\t"                                        \
+    "str x12, [" base_reg ", #96]\n\t"                                        \
+    "str x13, [" base_reg ", #104]\n\t"                                       \
+    "str x14, [" base_reg ", #112]\n\t"                                       \
+    "str x15, [" base_reg ", #120]\n\t"                                       \
+    "str x16, [" base_reg ", #128]\n\t"                                       \
+    "str x17, [" base_reg ", #136]\n\t"                                       \
+    "str x18, [" base_reg ", #144]\n\t"                                       \
+    "str x19, [" base_reg ", #152]\n\t"                                       \
+    "str x20, [" base_reg ", #160]\n\t"                                       \
+    "str x21, [" base_reg ", #168]\n\t"                                       \
+    "str x22, [" base_reg ", #176]\n\t"                                       \
+    "str x23, [" base_reg ", #184]\n\t"                                       \
+    "str x24, [" base_reg ", #192]\n\t"                                       \
+    "str x25, [" base_reg ", #200]\n\t"                                       \
+    "str x26, [" base_reg ", #208]\n\t"                                       \
+    "str x27, [" base_reg ", #216]\n\t"                                       \
+    "str x28, [" base_reg ", #224]\n\t"                                       \
+    "str x29, [" base_reg ", #232]\n\t"                                       \
+    "str x30, [" base_reg ", #240]\n\t"
+
+static uint64_t exception_capture_psci_affinity_info(uint64_t affinity,
+                                                     uint64_t *gGPRS,
+                                                     uint64_t *lGPRS)
+{
+    uint64_t ret;
+
+    /*
+     * Capture x0-x30 immediately before the PSCI exit and immediately after
+     * resume in one asm block so the compiler cannot insert C code between
+     * the SMC and the second snapshot.
+     */
+    __asm__ volatile(
+        EXCEPTION_STORE_ALL_GPRS("%x[before]")
+        "mov x0, %x[fid]\n\t"
+        "mov x1, %x[target_affinity]\n\t"
+        "mov x2, xzr\n\t"
+        "mov x3, xzr\n\t"
+        "smc #0\n\t"
+        EXCEPTION_STORE_ALL_GPRS("%x[after]")
+        "mov %x[result], x0\n\t"
+        : [result] "=&r" (ret)
+        : [before] "r" (gGPRS),
+          [after] "r" (lGPRS),
+          [fid] "r" ((uint64_t)PSCI_AFFINITY_INFO_AARCH64),
+          [target_affinity] "r" (affinity)
+        : "memory", "cc");
+
+    return ret;
+}
 
 void exception_rec_exit_psci_realm(void)
 {
     uint64_t index = 0, affinity = 0, mpidr = 0, ret;
-    int lGPRS[EXCEPTION_TEST_MAX_GPRS];
-    int gGPRS[EXCEPTION_TEST_MAX_GPRS];
-
-    register int x0 __asm("x0");
-    register int x1 __asm("x1");
-    register int x2 __asm("x2");
-    register int x3 __asm("x3");
-    register int x4 __asm("x4");
-    register int x5 __asm("x5");
-    register int x6 __asm("x6");
-    register int x7 __asm("x7");
-    register int x8 __asm("x8");
-    register int x9 __asm("x9");
-    register int x10 __asm("x10");
-    register int x11 __asm("x11");
-    register int x12 __asm("x12");
-    register int x13 __asm("x13");
-    register int x14 __asm("x14");
-    register int x15 __asm("x15");
-    register int x16 __asm("x16");
-    register int x17 __asm("x17");
-    register int x18 __asm("x18");
-    register int x19 __asm("x19");
-    register int x20 __asm("x20");
-    register int x21 __asm("x21");
-    register int x22 __asm("x22");
-    register int x23 __asm("x23");
-    register int x24 __asm("x24");
-    register int x25 __asm("x25");
-    register int x26 __asm("x26");
-    register int x27 __asm("x27");
-    register int x28 __asm("x28");
-    register int x29 __asm("x29");
-    register int x30 __asm("x30");
-
-    #define GET_GPRS_VALUES(gprs_array) \
-        do { \
-            gprs_array[0] = x0; \
-            gprs_array[0] = x0; \
-            gprs_array[1] = x1; \
-            gprs_array[2] = x2; \
-            gprs_array[3] = x3; \
-            gprs_array[4] = x4; \
-            gprs_array[5] = x5; \
-            gprs_array[6] = x6; \
-            gprs_array[7] = x7; \
-            gprs_array[8] = x8; \
-            gprs_array[9] = x9; \
-            gprs_array[10] = x10; \
-            gprs_array[11] = x11; \
-            gprs_array[12] = x12; \
-            gprs_array[13] = x13; \
-            gprs_array[14] = x14; \
-            gprs_array[15] = x15; \
-            gprs_array[16] = x16; \
-            gprs_array[17] = x17; \
-            gprs_array[18] = x18; \
-            gprs_array[19] = x19; \
-            gprs_array[20] = x20; \
-            gprs_array[21] = x21; \
-            gprs_array[22] = x22; \
-            gprs_array[23] = x23; \
-            gprs_array[24] = x24; \
-            gprs_array[25] = x25; \
-            gprs_array[26] = x26; \
-            gprs_array[27] = x27; \
-            gprs_array[28] = x28; \
-            gprs_array[29] = x29; \
-            gprs_array[30] = x30; \
-        } while (0)
+    uint64_t lGPRS[EXCEPTION_TEST_MAX_GPRS];
+    uint64_t gGPRS[EXCEPTION_TEST_MAX_GPRS];
 
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
-    /* Before triggering the rec exit(dueto hostcall) save the gprs values */
-    GET_GPRS_VALUES(gGPRS);
     mpidr = 1;
+
     /* get the second rec affinity*/
     affinity = EXCEPTION_AFFINITY_FROM_MPIDR(mpidr);
-    LOG(TEST, "Affinity info: mpidr : 0x%x, affinity : %d  \n",\
+    LOG(TEST, "Affinity info: mpidr : 0x%x, affinity : %d  \n", \
               mpidr, affinity);
-    /* testing the rec exit dueto psci affinity info */
-    val_psci_affinity_info(affinity, 0);
 
-    /* Upon rec enter again Read the gprs again and compare with earlier saved one */
-    GET_GPRS_VALUES(lGPRS);
+    ret = exception_capture_psci_affinity_info(affinity, gGPRS, lGPRS);
 
-    for (index = 0; index < EXCEPTION_TEST_PSCI_GPRS_CHECK_COUNT; index++)
+    /*
+     * PSCI_AFFINITY_INFO returns the target CPU state, not PSCI_E_SUCCESS.
+     * This probe is used here to force a PSCI REC exit and validate that
+     * x7-x30 are restored correctly on resume.
+     */
+    LOG(TEST, "PSCI_AFFINITY_INFO return value : 0x%x \n", ret);
+
+    for (index = EXCEPTION_TEST_PSCI_GPRS_COMPARE_START;
+         index < EXCEPTION_TEST_MAX_GPRS; index++)
     {
         if (gGPRS[index] != lGPRS[index])
         {
@@ -107,7 +105,6 @@ void exception_rec_exit_psci_realm(void)
             goto test_exit;
         }
     }
-
     /* Check for host rejecting PSCI request */
     ret = val_psci_cpu_on(affinity, val_realm_get_secondary_cpu_entry(), CONTEXT_ID);
     if (ret != PSCI_E_DENIED)
@@ -117,10 +114,8 @@ void exception_rec_exit_psci_realm(void)
         goto test_exit;
     }
 
-
     LOG(TEST, "REALM PSCI Trigger checks are verified \n");
 
 test_exit:
     val_realm_return_to_host();
 }
-

--- a/test/exception/exception_rec_exit_wfe/exception_rec_exit_wfe_host.c
+++ b/test/exception/exception_rec_exit_wfe/exception_rec_exit_wfe_host.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -63,12 +63,11 @@ void exception_rec_exit_wfe_host(void)
     LOG(TEST, "WFE Trigger verified \n");
     *wfe_trig = true;
 
-    /* populate the rec exit details into the rec enter and corrupt some possible gprs
-     * in the range 0-6
-     */
+    /* Populate the rec exit details into the rec enter */
     exception_copy_exit_to_entry(rec_enter, rec_exit);
+    rec_enter_flags.trap_wfe = 0;
+    rec_enter_flags.trap_wfi = 0;
     val_memcpy(&rec_enter->flags, &rec_enter_flags, sizeof(rec_enter_flags));
-    rec_enter->gprs[5] = 0;
     ret = val_host_rmi_rec_enter(realm.rec[0], realm.run[0]);
     if (ret != 0)
     {

--- a/test/exception/exception_rec_exit_wfe/exception_rec_exit_wfe_realm.c
+++ b/test/exception/exception_rec_exit_wfe/exception_rec_exit_wfe_realm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -8,76 +8,53 @@
 
 void exception_rec_exit_wfe_realm(void)
 {
-    register int x0 __asm("x0");
-    register int x1 __asm("x1");
-    register int x2 __asm("x2");
-    register int x3 __asm("x3");
-    register int x4 __asm("x4");
-    register int x5 __asm("x5");
-    register int x6 __asm("x6");
-    register int x7 __asm("x7");
-    register int x8 __asm("x8");
-    register int x9 __asm("x9");
-    register int x10 __asm("x10");
-    register int x11 __asm("x11");
-    register int x12 __asm("x12");
-    register int x13 __asm("x13");
-    register int x14 __asm("x14");
-    register int x15 __asm("x15");
-    register int x16 __asm("x16");
-    register int x17 __asm("x17");
-    register int x18 __asm("x18");
-    register int x19 __asm("x19");
-    register int x20 __asm("x20");
-    register int x21 __asm("x21");
-    register int x22 __asm("x22");
-    register int x23 __asm("x23");
-    register int x24 __asm("x24");
-    register int x25 __asm("x25");
-    register int x26 __asm("x26");
-    register int x27 __asm("x27");
-    register int x28 __asm("x28");
-    register int x29 __asm("x29");
-    register int x30 __asm("x30");
-
-    #define GET_GPRS_VALUES(gprs_array) \
-        do { \
-            gprs_array[0] = x0; \
-            gprs_array[0] = x0; \
-            gprs_array[1] = x1; \
-            gprs_array[2] = x2; \
-            gprs_array[3] = x3; \
-            gprs_array[4] = x4; \
-            gprs_array[5] = x5; \
-            gprs_array[6] = x6; \
-            gprs_array[7] = x7; \
-            gprs_array[8] = x8; \
-            gprs_array[9] = x9; \
-            gprs_array[10] = x10; \
-            gprs_array[11] = x11; \
-            gprs_array[12] = x12; \
-            gprs_array[13] = x13; \
-            gprs_array[14] = x14; \
-            gprs_array[15] = x15; \
-            gprs_array[16] = x16; \
-            gprs_array[17] = x17; \
-            gprs_array[18] = x18; \
-            gprs_array[19] = x19; \
-            gprs_array[20] = x20; \
-            gprs_array[21] = x21; \
-            gprs_array[22] = x22; \
-            gprs_array[23] = x23; \
-            gprs_array[24] = x24; \
-            gprs_array[25] = x25; \
-            gprs_array[26] = x26; \
-            gprs_array[27] = x27; \
-            gprs_array[28] = x28; \
-            gprs_array[29] = x29; \
-            gprs_array[30] = x30; \
+    /*
+     * Capture x0-x30 in one asm block directly to memory.
+     * This avoids using register-bound C variables like:
+     *   register int x29 __asm("x29");
+     * which Coverity reports as uninitialized scalar usage.
+     */
+    #define GET_GPRS_VALUES(gprs_array)                                      \
+        do {                                                                 \
+            __asm__ volatile(                                                \
+                "str x0,  [%0, #0]\n\t"                                      \
+                "str x1,  [%0, #8]\n\t"                                      \
+                "str x2,  [%0, #16]\n\t"                                     \
+                "str x3,  [%0, #24]\n\t"                                     \
+                "str x4,  [%0, #32]\n\t"                                     \
+                "str x5,  [%0, #40]\n\t"                                     \
+                "str x6,  [%0, #48]\n\t"                                     \
+                "str x7,  [%0, #56]\n\t"                                     \
+                "str x8,  [%0, #64]\n\t"                                     \
+                "str x9,  [%0, #72]\n\t"                                     \
+                "str x10, [%0, #80]\n\t"                                     \
+                "str x11, [%0, #88]\n\t"                                     \
+                "str x12, [%0, #96]\n\t"                                     \
+                "str x13, [%0, #104]\n\t"                                    \
+                "str x14, [%0, #112]\n\t"                                    \
+                "str x15, [%0, #120]\n\t"                                    \
+                "str x16, [%0, #128]\n\t"                                    \
+                "str x17, [%0, #136]\n\t"                                    \
+                "str x18, [%0, #144]\n\t"                                    \
+                "str x19, [%0, #152]\n\t"                                    \
+                "str x20, [%0, #160]\n\t"                                    \
+                "str x21, [%0, #168]\n\t"                                    \
+                "str x22, [%0, #176]\n\t"                                    \
+                "str x23, [%0, #184]\n\t"                                    \
+                "str x24, [%0, #192]\n\t"                                    \
+                "str x25, [%0, #200]\n\t"                                    \
+                "str x26, [%0, #208]\n\t"                                    \
+                "str x27, [%0, #216]\n\t"                                    \
+                "str x28, [%0, #224]\n\t"                                    \
+                "str x29, [%0, #232]\n\t"                                    \
+                "str x30, [%0, #240]\n\t"                                    \
+                :                                                            \
+                : "r"(gprs_array)                                            \
+                : "memory");                                                 \
         } while (0)
     uint64_t index = 0;
-    int gGPRS[EXCEPTION_TEST_MAX_GPRS];
-    int lGPRS[EXCEPTION_TEST_MAX_GPRS];
+    uint64_t gGPRS[EXCEPTION_TEST_MAX_GPRS];
+    uint64_t lGPRS[EXCEPTION_TEST_MAX_GPRS];
     uint64_t *wfe_trig = (uint64_t *)(val_get_shared_region_base() + VAL_TEST_USE1);
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
@@ -90,7 +67,7 @@ void exception_rec_exit_wfe_realm(void)
         dsbsy();
 
         /* trigger the WFE to realm to exit */
-        __asm__("wfe");
+        __asm__ volatile("wfe" ::: "memory");
 
         /* Upon rec enter again Read the gprs again */
         GET_GPRS_VALUES(lGPRS);

--- a/test/exception/exception_rec_exit_wfi/exception_rec_exit_wfi_host.c
+++ b/test/exception/exception_rec_exit_wfi/exception_rec_exit_wfi_host.c
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -61,11 +61,8 @@ void exception_rec_exit_wfi_host(void)
     LOG(TEST, "Rec enter WFI Verified\n");
     *wfi_trig = true;
 
-    /* populate the rec exit details into the rec enter and corrupt some possible gprs
-     * in the range 0-6 */
+    /* Populate the rec exit details into the rec enter */
     exception_copy_exit_to_entry(rec_enter, rec_exit);
-
-    rec_enter->gprs[5] = 0;
     rec_enter_flags.trap_wfe = 0;
     rec_enter_flags.trap_wfi = 0;
     val_memcpy(&rec_enter->flags, &rec_enter_flags, sizeof(rec_enter_flags));

--- a/test/exception/exception_rec_exit_wfi/exception_rec_exit_wfi_realm.c
+++ b/test/exception/exception_rec_exit_wfi/exception_rec_exit_wfi_realm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -8,92 +8,70 @@
 
 void exception_rec_exit_wfi_realm(void)
 {
-    register int x0 __asm("x0");
-    register int x1 __asm("x1");
-    register int x2 __asm("x2");
-    register int x3 __asm("x3");
-    register int x4 __asm("x4");
-    register int x5 __asm("x5");
-    register int x6 __asm("x6");
-    register int x7 __asm("x7");
-    register int x8 __asm("x8");
-    register int x9 __asm("x9");
-    register int x10 __asm("x10");
-    register int x11 __asm("x11");
-    register int x12 __asm("x12");
-    register int x13 __asm("x13");
-    register int x14 __asm("x14");
-    register int x15 __asm("x15");
-    register int x16 __asm("x16");
-    register int x17 __asm("x17");
-    register int x18 __asm("x18");
-    register int x19 __asm("x19");
-    register int x20 __asm("x20");
-    register int x21 __asm("x21");
-    register int x22 __asm("x22");
-    register int x23 __asm("x23");
-    register int x24 __asm("x24");
-    register int x25 __asm("x25");
-    register int x26 __asm("x26");
-    register int x27 __asm("x27");
-    register int x28 __asm("x28");
-    register int x29 __asm("x29");
-    register int x30 __asm("x30");
-
-    #define GET_GPRS_VALUES(gprs_array) \
-        do { \
-            gprs_array[0] = x0; \
-            gprs_array[0] = x0; \
-            gprs_array[1] = x1; \
-            gprs_array[2] = x2; \
-            gprs_array[3] = x3; \
-            gprs_array[4] = x4; \
-            gprs_array[5] = x5; \
-            gprs_array[6] = x6; \
-            gprs_array[7] = x7; \
-            gprs_array[8] = x8; \
-            gprs_array[9] = x9; \
-            gprs_array[10] = x10; \
-            gprs_array[11] = x11; \
-            gprs_array[12] = x12; \
-            gprs_array[13] = x13; \
-            gprs_array[14] = x14; \
-            gprs_array[15] = x15; \
-            gprs_array[16] = x16; \
-            gprs_array[17] = x17; \
-            gprs_array[18] = x18; \
-            gprs_array[19] = x19; \
-            gprs_array[20] = x20; \
-            gprs_array[21] = x21; \
-            gprs_array[22] = x22; \
-            gprs_array[23] = x23; \
-            gprs_array[24] = x24; \
-            gprs_array[25] = x25; \
-            gprs_array[26] = x26; \
-            gprs_array[27] = x27; \
-            gprs_array[28] = x28; \
-            gprs_array[29] = x29; \
-            gprs_array[30] = x30; \
+    /*
+     * Capture x0-x30 in one asm block directly to memory.
+     * This avoids using register-bound C variables like:
+     *   register int x29 __asm("x29");
+     * which Coverity reports as uninitialized scalar usage.
+     */
+    #define GET_GPRS_VALUES(gprs_array)                                      \
+        do {                                                                 \
+            __asm__ volatile(                                                \
+                "str x0,  [%0, #0]\n\t"                                      \
+                "str x1,  [%0, #8]\n\t"                                      \
+                "str x2,  [%0, #16]\n\t"                                     \
+                "str x3,  [%0, #24]\n\t"                                     \
+                "str x4,  [%0, #32]\n\t"                                     \
+                "str x5,  [%0, #40]\n\t"                                     \
+                "str x6,  [%0, #48]\n\t"                                     \
+                "str x7,  [%0, #56]\n\t"                                     \
+                "str x8,  [%0, #64]\n\t"                                     \
+                "str x9,  [%0, #72]\n\t"                                     \
+                "str x10, [%0, #80]\n\t"                                     \
+                "str x11, [%0, #88]\n\t"                                     \
+                "str x12, [%0, #96]\n\t"                                     \
+                "str x13, [%0, #104]\n\t"                                    \
+                "str x14, [%0, #112]\n\t"                                    \
+                "str x15, [%0, #120]\n\t"                                    \
+                "str x16, [%0, #128]\n\t"                                    \
+                "str x17, [%0, #136]\n\t"                                    \
+                "str x18, [%0, #144]\n\t"                                    \
+                "str x19, [%0, #152]\n\t"                                    \
+                "str x20, [%0, #160]\n\t"                                    \
+                "str x21, [%0, #168]\n\t"                                    \
+                "str x22, [%0, #176]\n\t"                                    \
+                "str x23, [%0, #184]\n\t"                                    \
+                "str x24, [%0, #192]\n\t"                                    \
+                "str x25, [%0, #200]\n\t"                                    \
+                "str x26, [%0, #208]\n\t"                                    \
+                "str x27, [%0, #216]\n\t"                                    \
+                "str x28, [%0, #224]\n\t"                                    \
+                "str x29, [%0, #232]\n\t"                                    \
+                "str x30, [%0, #240]\n\t"                                    \
+                :                                                            \
+                : "r"(gprs_array)                                            \
+                : "memory");                                                 \
         } while (0)
 
     uint64_t index = 0;
-    int gGPRS[EXCEPTION_TEST_MAX_GPRS];
-    int lGPRS[EXCEPTION_TEST_MAX_GPRS];
+    uint64_t gGPRS[EXCEPTION_TEST_MAX_GPRS];
+    uint64_t lGPRS[EXCEPTION_TEST_MAX_GPRS];
     uint64_t *wfi_trig = (uint64_t *)(val_get_shared_region_base() + VAL_TEST_USE1);
+
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
     /* Execute WFI in a loop to avoid conditions where PE treating it as NOP */
     for (uint8_t i = 0; i < WFX_ITERATIONS; i++)
     {
-        /* Before triggering the rec exit(dueto wfi) save the gprs values */
+        /* Before triggering the rec exit (due to WFI) save the GPR values */
         GET_GPRS_VALUES(gGPRS);
 
         dsbsy();
 
         /* Trigger the WFI for rec exit */
-        __asm__("wfi");
+        __asm__ volatile("wfi" ::: "memory");
 
-        /* Upon rec enter again Read the gprs again */
+        /* Upon rec enter again read the GPRs again */
         GET_GPRS_VALUES(lGPRS);
 
         dsbsy();
@@ -105,18 +83,18 @@ void exception_rec_exit_wfi_realm(void)
     /* Fail the test if WFI is not triggered */
     if (*wfi_trig == false)
     {
-            LOG(ERROR, "WFI not triggered\n");
-            val_set_status(RESULT_FAIL(VAL_ERROR_POINT(1)));
-            goto test_exit;
+        LOG(ERROR, "WFI not triggered\n");
+        val_set_status(RESULT_FAIL(VAL_ERROR_POINT(1)));
+        goto test_exit;
     }
 
-    /* Compare the new gprs with earlier saved one */
+    /* Compare the new GPRs with earlier saved ones */
     for (index = 0; index < EXCEPTION_TEST_MAX_GPRS; index++)
     {
         if (gGPRS[index] != lGPRS[index])
         {
-            LOG(ERROR, "WFI check, the gprs value is corrupted, \
-                             hence testcase failed\n");
+            LOG(ERROR, "WFI check, the gprs value is corrupted, "
+                       "hence testcase failed\n");
             val_set_status(RESULT_FAIL(VAL_ERROR_POINT(2)));
             goto test_exit;
         }
@@ -127,3 +105,4 @@ void exception_rec_exit_wfi_realm(void)
 test_exit:
     val_realm_return_to_host();
 }
+

--- a/test/rhi/rhi_da_object_read/rhi_da_object_read_host.c
+++ b/test/rhi/rhi_da_object_read/rhi_da_object_read_host.c
@@ -44,7 +44,7 @@ void rhi_da_object_read_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
     uint64_t i;
     struct step_desc {
         const char *desc;
@@ -60,8 +60,8 @@ void rhi_da_object_read_host(void)
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_LOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_LOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -84,12 +84,12 @@ void rhi_da_object_read_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
 
     for (i = 0; i < (sizeof(step_desc) / sizeof(step_desc[0])); i++)
     {
         LOG(ALWAYS, "RHI_DA_OBJECT_READ: %s\n", step_desc[i].desc);
-        ret = rhi_da_step(&realm, &pdev_obj, &vdev_obj);
+        ret = rhi_da_step(&realm, &pdev_obj, vdev_obj);
         if (ret)
             goto destroy_device;
     }
@@ -105,7 +105,7 @@ void rhi_da_object_read_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(8)));
         goto destroy_realm;

--- a/test/rhi/rhi_da_object_size/rhi_da_object_size_host.c
+++ b/test/rhi/rhi_da_object_size/rhi_da_object_size_host.c
@@ -14,12 +14,12 @@ void rhi_da_object_size_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_LOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_LOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -42,7 +42,7 @@ void rhi_da_object_size_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
     ret = val_host_rmi_rec_enter(realm.rec[0], realm.run[0]);
     if (ret)
     {
@@ -56,7 +56,7 @@ void rhi_da_object_size_host(void)
         goto destroy_device;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -77,7 +77,7 @@ void rhi_da_object_size_host(void)
         goto destroy_device;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -98,7 +98,7 @@ void rhi_da_object_size_host(void)
         goto destroy_device;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -119,7 +119,7 @@ void rhi_da_object_size_host(void)
         goto destroy_device;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -138,7 +138,7 @@ void rhi_da_object_size_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(17)));
         goto destroy_realm;

--- a/test/rhi/rhi_da_vdev_abort/rhi_da_vdev_abort_host.c
+++ b/test/rhi/rhi_da_vdev_abort/rhi_da_vdev_abort_host.c
@@ -14,12 +14,12 @@ void rhi_da_vdev_abort_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_NEW);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_NEW);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -42,7 +42,7 @@ void rhi_da_vdev_abort_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
     ret = val_host_rmi_rec_enter(realm.rec[0], realm.run[0]);
     if (ret)
     {
@@ -56,7 +56,7 @@ void rhi_da_vdev_abort_host(void)
         goto destroy_realm;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -77,7 +77,7 @@ void rhi_da_vdev_abort_host(void)
         goto destroy_realm;
     }
 
-    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, &vdev_obj);
+    ret = val_host_rhi_da_dispatch(&realm, &pdev_obj, vdev_obj);
     if (ret)
     {
         LOG(ERROR, "RHI command failed, ret=%lx\n", ret);
@@ -92,7 +92,7 @@ void rhi_da_vdev_abort_host(void)
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(10)));
         goto destroy_realm;
     }
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         LOG(ERROR, "VDEV teardown failed\n");
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(11)));

--- a/test/rhi/rhi_da_vdev_continue/rhi_da_vdev_continue_host.c
+++ b/test/rhi/rhi_da_vdev_continue/rhi_da_vdev_continue_host.c
@@ -57,13 +57,13 @@ void rhi_da_vdev_continue_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
     uint64_t rc;
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_LOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_LOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -86,11 +86,11 @@ void rhi_da_vdev_continue_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
 
     for (;;)
     {
-        rc = rhi_da_step(&realm, &pdev_obj, &vdev_obj);
+        rc = rhi_da_step(&realm, &pdev_obj, vdev_obj);
         if (rc == RHI_DA_STEP_DONE)
             break;
         if (rc == RHI_DA_STEP_ERROR)
@@ -100,7 +100,7 @@ void rhi_da_vdev_continue_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         LOG(ERROR, "VDEV teardown failed\n");
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(7)));

--- a/test/rhi/rhi_da_vdev_get_interface_report/rhi_da_vdev_get_interface_report_host.c
+++ b/test/rhi/rhi_da_vdev_get_interface_report/rhi_da_vdev_get_interface_report_host.c
@@ -57,13 +57,13 @@ void rhi_da_vdev_get_interface_report_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
     uint64_t rc;
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_LOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_LOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -86,11 +86,11 @@ void rhi_da_vdev_get_interface_report_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
 
     for (;;)
     {
-        rc = rhi_da_step(&realm, &pdev_obj, &vdev_obj);
+        rc = rhi_da_step(&realm, &pdev_obj, vdev_obj);
         if (rc == RHI_DA_STEP_DONE)
             break;
         if (rc == RHI_DA_STEP_ERROR)
@@ -100,7 +100,7 @@ void rhi_da_vdev_get_interface_report_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         LOG(ERROR, "VDEV teardown failed\n");
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(7)));

--- a/test/rhi/rhi_da_vdev_get_measurements/rhi_da_vdev_get_measurements_host.c
+++ b/test/rhi/rhi_da_vdev_get_measurements/rhi_da_vdev_get_measurements_host.c
@@ -57,14 +57,14 @@ void rhi_da_vdev_get_measurements_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
     uint64_t params_ipa;
     uint64_t rc;
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_LOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_LOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -95,12 +95,12 @@ void rhi_da_vdev_get_measurements_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
     rec_enter->gprs[2] = params_ipa;
 
     for (;;)
     {
-        rc = rhi_da_step(&realm, &pdev_obj, &vdev_obj);
+        rc = rhi_da_step(&realm, &pdev_obj, vdev_obj);
         if (rc == RHI_DA_STEP_DONE)
             break;
         if (rc == RHI_DA_STEP_ERROR)
@@ -110,7 +110,7 @@ void rhi_da_vdev_get_measurements_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         LOG(ERROR, "VDEV teardown failed\n");
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(8)));

--- a/test/rhi/rhi_da_vdev_set_tdi_state/rhi_da_vdev_set_tdi_state_host.c
+++ b/test/rhi/rhi_da_vdev_set_tdi_state/rhi_da_vdev_set_tdi_state_host.c
@@ -45,7 +45,7 @@ void rhi_da_vdev_set_tdi_state_host(void)
     uint64_t ret;
     val_host_rec_enter_ts *rec_enter = NULL;
     val_host_pdev_ts pdev_obj;
-    val_host_vdev_ts vdev_obj;
+    val_host_vdev_ts vdev_obj[2];
     uint64_t i;
     const char *step_desc[] = {
         "invalid vdev id",
@@ -56,8 +56,8 @@ void rhi_da_vdev_set_tdi_state_host(void)
 
     val_memset(&realm, 0, sizeof(realm));
     val_memset(&pdev_obj, 0, sizeof(pdev_obj));
-    val_memset(&vdev_obj, 0, sizeof(vdev_obj));
-    ret = da_init(&realm, &pdev_obj, &vdev_obj, RMI_VDEV_UNLOCKED);
+    val_memset(vdev_obj, 0, sizeof(vdev_obj));
+    ret = da_init(&realm, &pdev_obj, vdev_obj, RMI_VDEV_UNLOCKED);
     if (ret)
     {
         LOG(ERROR, "DA init failed, ret=%lx\n", ret);
@@ -80,12 +80,12 @@ void rhi_da_vdev_set_tdi_state_host(void)
     }
 
     rec_enter = &(((val_host_rec_run_ts *)realm.run[0])->enter);
-    rec_enter->gprs[1] = vdev_obj.vdev_id;
+    rec_enter->gprs[1] = vdev_obj[0].vdev_id;
 
     for (i = 0; i < (sizeof(step_desc) / sizeof(step_desc[0])); i++)
     {
         LOG(ALWAYS, "RHI_DA_VDEV_SET_TDI_STATE: %s\n", step_desc[i]);
-        ret = rhi_da_step(&realm, &pdev_obj, &vdev_obj);
+        ret = rhi_da_step(&realm, &pdev_obj, vdev_obj);
         if (ret)
             goto destroy_device;
     }
@@ -101,7 +101,7 @@ void rhi_da_vdev_set_tdi_state_host(void)
     val_set_status(RESULT_PASS(VAL_SUCCESS));
 
 destroy_device:
-    if (val_host_vdev_teardown(&realm, &pdev_obj, &vdev_obj))
+    if (val_host_vdev_teardown(&realm, &pdev_obj, vdev_obj))
     {
         LOG(ERROR, "VDEV teardown failed\n");
         val_set_status(RESULT_FAIL(VAL_ERROR_POINT(8)));

--- a/val/host/src/val_host_rmi.c
+++ b/val/host/src/val_host_rmi.c
@@ -278,7 +278,7 @@ uint64_t val_host_rmi_rec_destroy(uint64_t rec)
 uint64_t val_host_rmi_rec_enter(uint64_t rec, uint64_t run_ptr)
 {
     val_host_rec_run_ts *run = (val_host_rec_run_ts *)run_ptr;
-    val_host_rec_enter_flags_ts rec_enter_flags;
+    val_host_rec_enter_flags_ts rec_enter_flags = {0};
     uint64_t ret;
 
 rec_enter:


### PR DESCRIPTION
Address actionable Coverity issues reported for RMM ACS sources.

- read GPRs via inline asm to avoid UNINIT reports in realm exit tests

- zero-init realm/flags structures before passing to helpers

- fix token buffer pointer arithmetic in attestation IRQ realm test

- add VMID bounds checks in RTT destroy/unmap tests

- pass vdev arrays to RHI DA dispatcher to avoid singleton OOB

This resolves the local Coverity findings from coverity_reports.

Third-party findings under external/mbedtls and external/qcbor are not

changed here.

Fixed exception_rec_exit_psci test for capturing registers before and after smc call through asm code

Change-Id: Iecd91fc8dc14620981a936f0c828d32809d5b863